### PR TITLE
[ADD] footil/log.py: get_formatted_exception

### DIFF
--- a/footil/log.py
+++ b/footil/log.py
@@ -2,7 +2,10 @@ import io
 import contextlib
 from typing import Optional
 import logging
-
+import traceback
+import sys
+import yattag
+import uuid
 
 LOG_FORMAT = '%(asctime)s %(levelname)s %(filename)s: %(message)s'
 
@@ -39,3 +42,127 @@ def setup_logger(
     logging.basicConfig(
         format=LOG_FORMAT,
         level=log_level)
+
+
+def format_list_to_html(
+        line_height=1, collapse_cfg: Optional[dict] = None) -> str:
+    """Format list of strings into HTML string.
+
+    Lines are converted into HTML paragraphs. line-height attribute is
+    set for all paragraphs. This is default format.
+
+    Optionally can specify collapse_cfg to make part of text
+    "togglable" (aka read more/read less). Two ways are supported:
+        - bootrstrap collapse (default).
+        - attr_toggle on div that is "togglable".
+
+    In both cases max_lines key is required.
+
+    First case is used if max_lines is specified (maximum lines to
+    show initially), but not attr_toggle. Optionally collapse_id can be
+    passed to use it as anchor for bootsrap collapse toggle. Otherwise
+    str(uuid.uuid4()) value is used.
+
+    Second case is used if attr_toggle is used. This way only specified
+    custom attribute is added on div that wraps paragraphs that should
+    be hidden initially. Paragraphs toggle implementation must be done
+    externally in this case.
+
+    Args:
+        line_height: paragraph height (default: {1})
+        collapse_cfg: toggle show/hide part of text config
+            (default: {None}) Used keys:
+              - max_lines (int): number of paragraphs to show initially.
+              - collapse_id (str): anchor for collapse div
+                identification. If not set, will use randomly generated
+                ID. Bootstrap implementation only.
+              - attr_toggle (tuple): attribute used to toggle show/hide
+                part of text. Custom implementation only.
+
+    Returns:
+        HTML string
+    """
+    def build_lines(lines):
+        for line in lines:
+            # Assuming that line is one paragraph, so `\n` is not needed.
+            line = line.replace('\n', '')
+            with tag('p'):
+                text(line)
+
+    def build_bootstrap_collapse(lines_to_hide):
+        # Default to random ID if none was specified. It has
+        # very low chance to run in collision, so there should
+        # be no problem.
+        collapse_id = (
+            collapse_cfg.get('collapse_id') or str(uuid.uuid4()))
+        with tag('div', id=collapse_id, klass='collapse'):
+            build_lines(lines_to_hide)
+        # Add button to toggle hidden lines.
+        with tag(
+            'a',
+            ('data-toggle', 'collapse'),
+            ('data-target', '#%s' % collapse_id),
+                klass='btn btn-link'):
+            text('Toggle More')
+
+    def format_html(lines):
+        with tag('div'):
+            doc.attr(style='line-height: %s' % line_height)
+            max_lines = collapse_cfg['max_lines']
+            if max_lines == -1:  # Everything is showed.
+                build_lines(lines)
+            else:
+                # Split into lines to show and to hide.
+                # Lines to hide.
+                lines_to_show = lines[0:max_lines]
+                lines_to_hide = lines[max_lines:]
+                # Build lines that will be visible all the time.
+                build_lines(lines_to_show)
+                # Build lines that will be hidden initially.
+                if collapse_cfg.get('attr_toggle'):
+                    # Using custom specified attribute that should be
+                    # used to handle toggling of lines_to_hide (
+                    # implementation must be done externally from this
+                    # method).
+                    with tag('div', collapse_cfg['attr_toggle']):
+                        build_lines(lines_to_hide)
+                else:
+                    # Default to bootstrap implementation.
+                    build_bootstrap_collapse(lines_to_hide)
+        return doc.getvalue()
+
+    if not collapse_cfg:
+        collapse_cfg = {'max_lines': -1}
+    doc, tag, text = yattag.Doc().tagtext()
+    return format_html
+
+
+def _format_exception() -> list:
+    exc_type, exc_value, exc_traceback = sys.exc_info()
+    return traceback.format_exception(exc_type, exc_value, exc_traceback)
+
+
+def _get_formatted_exception(
+        exc_lines: list, formatter=None) -> str:
+    if not formatter:
+        return ''.join(exc_lines)
+    return formatter(exc_lines)
+
+
+def get_formatted_exception(formatter=None) -> str:
+    """Convert exception lines into formatter string.
+
+    How string is formatted, depends on formatter function passed.
+    Formatter acts as constructor, so it needs to be executed where its
+    closure function can take specified arguments (if there are any) and
+    do actual formatting.
+
+    Args:
+        formatter: logic how to format (default: {None}). If not
+        specified will default to ''.join(exc_lines).
+
+    Returns:
+        formatted exception lines string
+    """
+    exc_lines = _format_exception()
+    return _get_formatted_exception(exc_lines, formatter=formatter)

--- a/footil/tests/test_log.py
+++ b/footil/tests/test_log.py
@@ -1,32 +1,129 @@
 import unittest
-import logging
 
 from footil import log
+import xml.etree.ElementTree as ET
 
 
 class TestLog(unittest.TestCase):
-    """Class to test stdout/stderr helpers."""
+    """Class to test logging/formatting helpers."""
 
-    def test_log_1(self):
+    @classmethod
+    def setUpClass(cls):
+        """Set up data for log tests."""
+        super(TestLog, cls).setUpClass()
+        cls.dummy_lst = [
+            'traceback:\n', 'something_went_wrong\n', 'some_error\n']
+
+    def test_capture_output_1(self):
         """Capture output from print."""
         res = log.capture_output(print, args=('test',))
         self.assertEqual(res, 'test\n')
 
-    # TODO: There might be a bug with logging, so disabled tests for
-    # now.
-    # def test_log_2(self):
-    #     """Capture output from logging."""
-    #     res = log.capture_output(
-    #         lambda a=10: logging.warning(a), kwargs={'a': 'test2'})
-    #     self.assertEqual(res, 'WARNING:root:test2\n')
+    def test_formatted_exception_1(self):
+        """Use default formatting for exception list (no formatter)."""
+        res = log._get_formatted_exception(self.dummy_lst)
+        self.assertEqual(res, 'traceback:\nsomething_went_wrong\nsome_error\n')
 
-    # def test_log_3(self):
-    #     """Capture output from both print and logging."""
+    def test_formatted_exception_2(self):
+        """Use html formatter for exception list.
 
-    #     def dummy(a, b='dummy'):
-    #         print(a)
-    #         logging.warning(b)
+        Case: full message is showed.
+        """
+        res = log._get_formatted_exception(
+            self.dummy_lst, formatter=log.format_list_to_html())
+        dest = (
+            '<div style="line-height: 1"><p>traceback:</p>'
+            '<p>something_went_wrong</p>'
+            '<p>some_error</p>'
+            '</div>')
+        self.assertEqual(res, dest)
+        # Format it with line_height specified.
+        res = log._get_formatted_exception(
+            self.dummy_lst, formatter=log.format_list_to_html(
+                line_height=0))
+        dest = (
+            '<div style="line-height: 0"><p>traceback:</p>'
+            '<p>something_went_wrong</p>'
+            '<p>some_error</p>'
+            '</div>')
+        self.assertEqual(res, dest)
 
-    #     res = log.capture_output(
-    #         dummy, args=('test3',), kwargs={'b': 'test4'})
-    #     self.assertEqual(res, 'test3\nWARNING:root:test4\n')
+    def test_formatted_exception_3(self):
+        """Use html formatter for exception list.
+
+        Case: part of message is showed. Default bootstrap collapse is
+        used to toggle hidden part of message.
+        """
+        # Format it with collapse configuration.
+        res = log._get_formatted_exception(
+            self.dummy_lst, formatter=log.format_list_to_html(
+                collapse_cfg={'max_lines': 1, 'collapse_id': 'test_1'}))
+        tree = ET.ElementTree(ET.fromstring(res))
+        # Check tree if it matches expected structure.
+        root = tree.getroot()
+        self.assertEqual(root.items(), [('style', 'line-height: 1')])
+        # Check root children.
+        root_childs = root.getchildren()
+        self.assertEqual(len(root_childs), 3)
+        p = root_childs[0]
+        self.assertEqual(p.text, 'traceback:')
+        div = root_childs[1]
+        self.assertEqual(
+            sorted(div.items()), [('class', 'collapse'), ('id', 'test_1'), ])
+        div_childs = div.getchildren()
+        self.assertEqual(len(div_childs), 2)
+        self.assertEqual(div_childs[0].text, 'something_went_wrong')
+        self.assertEqual(div_childs[1].text, 'some_error')
+        a = root_childs[2]
+        self.assertEqual(
+            sorted(a.items()),
+            [
+                ('class', 'btn btn-link'),
+                ('data-target', '#test_1'),
+                ('data-toggle', 'collapse')
+            ]
+        )
+        self.assertEqual(a.text, 'Toggle More')
+        # Check if uuid4 is used when collapse_id is not specified.
+        res = log._get_formatted_exception(
+            self.dummy_lst, formatter=log.format_list_to_html(
+                collapse_cfg={'max_lines': 1}))
+        tree = ET.ElementTree(ET.fromstring(res))
+        root_childs = tree.getroot().getchildren()
+        div = root_childs[1]
+        div_id = dict(div.items())['id']
+        a = root_childs[2]
+        a_data_target = dict(a.items())['data-target']
+        # Slice to remove '#'.
+        self.assertEqual(div_id, a_data_target[1:])
+
+    def test_formatted_exception_4(self):
+        """Use html formatter for exception list.
+
+        Case: part of message is showed. Custom attribute is
+        included to specify part that needs to be hidden.
+        """
+        res = log._get_formatted_exception(
+            self.dummy_lst,
+            formatter=log.format_list_to_html(
+                collapse_cfg={
+                    'max_lines': 1,
+                    'attr_toggle': ('data-o-mail-quote', 1)
+                }
+            )
+        )
+        tree = ET.ElementTree(ET.fromstring(res))
+        # Check tree if it matches expected structure.
+        root = tree.getroot()
+        self.assertEqual(root.items(), [('style', 'line-height: 1')])
+        # Check root children.
+        root_childs = root.getchildren()
+        self.assertEqual(len(root_childs), 2)
+        p = root_childs[0]
+        self.assertEqual(p.text, 'traceback:')
+        div = root_childs[1]
+        self.assertEqual(div.items(), [('data-o-mail-quote', '1')])
+        div_childs = div.getchildren()
+        self.assertEqual(len(div_childs), 2)
+        self.assertEqual(div_childs[0].text, 'something_went_wrong')
+        self.assertEqual(div_childs[1].text, 'some_error')

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,9 @@ from distutils.core import setup
 
 setup(
     name='Footil',
-    version='0.1.0',
+    version='0.2.0',
     packages=['footil'],
     license='LGPLv3',
     long_description=open('README.rst').read(),
+    install_requires=['yattag']
 )


### PR DESCRIPTION
Exception traceback can be formatted into string. This could be used
when some formatting is needed before logging exception. Also added HTML
formatter that can be optionally passed to convert traceback into HTML
string.