### PR TITLE
[ADD] formatting.py: replace_email_name

### DIFF
--- a/footil/formatting.py
+++ b/footil/formatting.py
@@ -1,4 +1,4 @@
-"""Manipulate data to have different formats."""
+"""Manipulate data to have different format or output different data."""
 import traceback
 import sys
 import yattag
@@ -8,6 +8,7 @@ import ast
 from string import Formatter
 from operator import attrgetter
 import re
+from email.utils import parseaddr, formataddr
 
 from footil.lib import pattern_methods
 
@@ -244,3 +245,11 @@ def generate_names(
     return [
         (rec.id, generate_name(pattern, rec, strip_falsy=strip_falsy))
         for rec in objects]
+
+
+# Email formatting utilities.
+
+def replace_email_name(name: str, oldemail: str) -> str:
+    """Replace email name with new one."""
+    _, email_part = parseaddr(oldemail)
+    return formataddr((name, email_part))

--- a/footil/tests/test_formatting.py
+++ b/footil/tests/test_formatting.py
@@ -231,3 +231,33 @@ class TestFormatting(TestFootilCommon):
         objects_lst = [dummy_1_3, dummy_2_3]
         res = formatting.generate_names('{a.b.c} | {b}', objects_lst)
         self.assertEqual(res, [(1, '10 | something'), (2, '50 | something2')])
+
+    def test_replace_email_name_1(self):
+        """Replace name for email 'A <a@b.com>'."""
+        email = formatting.replace_email_name('B', 'A <a@b.com>')
+        self.assertEqual(email, 'B <a@b.com>')
+
+    def test_replace_email_name_2(self):
+        """Replace name for email '<a@b.com>'."""
+        email = formatting.replace_email_name('B', '<a@b.com>')
+        self.assertEqual(email, 'B <a@b.com>')
+
+    def test_replace_email_name_3(self):
+        """Replace name for email 'a@b.com'."""
+        email = formatting.replace_email_name('B', 'a@b.com')
+        self.assertEqual(email, 'B <a@b.com>')
+
+    def test_replace_email_name_4(self):
+        """Replace name for email 'A a@b.com'."""
+        email = formatting.replace_email_name('B', 'A a@b.com')
+        self.assertEqual(email, 'B <A a@b.com>')
+
+    def test_replace_email_name_5(self):
+        """Replace name for email ''."""
+        email = formatting.replace_email_name('B', '')
+        self.assertEqual(email, 'B <>')
+
+    def test_replace_email_name_6(self):
+        """Replace name for email '' when name is ''."""
+        email = formatting.replace_email_name('', '')
+        self.assertEqual(email, '')

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='footil',
-    version='0.6.0',
+    version='0.7.0',
     packages=['footil', 'footil.lib'],
     license='LGPLv3',
     url='https://github.com/focusate/footil',


### PR DESCRIPTION
Can be used to build email with new email name. Could be useful in cases
when incorrect email name is generated from some data and need to force
correct one.

[BRANCH] feature/replace-email-ala