### PR TITLE
[IMP] formatting.py: generate_names

### DIFF
--- a/footil/formatting.py
+++ b/footil/formatting.py
@@ -239,12 +239,42 @@ def generate_name(pattern: str, obj: object, strip_falsy: bool = True) -> str:
     return name
 
 
-def generate_names(
-        pattern: str, objects: object, strip_falsy: bool = True) -> list:
-    """Wrap generate_name and reuse for multiple objects."""
+def generate_names(cfg: dict) -> list:
+    """Wrap generate_name and reuse for multiple objects.
+
+    cfg keys:
+        pattern (str): pattern to generate name by. e.g.
+            'test {a.b} / {c}'
+        objects (iterable): iterable of objects to use.
+        strip_falsy (bool): whether to strip away falsy attribute
+            values or not. If stripped away, then leading string is
+            also stripped away for next attribute to not look like
+            '/ attr_value'. It instead just looks like 'attr_value'
+            (default: {True})
+        key (str): attribute name to put its value into tuple
+            (default: {'id'})
+
+    Returns:
+        list of tuple pairs, where first item is identifier, second
+        generated name string.
+
+    """
+    try:
+        pattern = cfg['pattern']
+        objects = cfg['objects']
+    except KeyError as e:
+        raise ValueError("cfg is missing required key '%s'" % e)
+    # strip falsy values is True on default.
+    strip_falsy = cfg.get('strip_falsy', True)
+    # Default key is 'id' attribute.
+    key = cfg.get('key', 'id')
     return [
-        (rec.id, generate_name(pattern, rec, strip_falsy=strip_falsy))
-        for rec in objects]
+        (
+            getattr(obj, key),
+            generate_name(pattern, obj, strip_falsy=strip_falsy)
+        )
+        for obj in objects
+    ]
 
 
 # Email formatting utilities.

--- a/footil/tests/test_formatting.py
+++ b/footil/tests/test_formatting.py
@@ -220,8 +220,8 @@ class TestFormatting(TestFootilCommon):
             dummy3, 'parent', 'name', '.',)
         self.assertEqual(res, '1.False.d3')
 
-    def test_generate_names(self):
-        """Generate names using iterator object."""
+    def test_generate_names_1(self):
+        """Generate names using iterator object. Default key."""
         dummy_1 = Dummy(c=10)
         dummy_1_2 = Dummy(b=dummy_1)
         dummy_1_3 = Dummy(a=dummy_1_2, b='something', id=1)
@@ -229,8 +229,37 @@ class TestFormatting(TestFootilCommon):
         dummy_2_2 = Dummy(b=dummy_2)
         dummy_2_3 = Dummy(a=dummy_2_2, b='something2', id=2)
         objects_lst = [dummy_1_3, dummy_2_3]
-        res = formatting.generate_names('{a.b.c} | {b}', objects_lst)
+        res = formatting.generate_names(
+            {'pattern': '{a.b.c} | {b}', 'objects': objects_lst})
         self.assertEqual(res, [(1, '10 | something'), (2, '50 | something2')])
+        # Generate names with empty list as objects value.
+        res = formatting.generate_names(
+            {'pattern': '{a.b.c} | {b}', 'objects': []})
+        self.assertEqual(res, [])
+        # Generate names with empty pattern.
+        res = formatting.generate_names(
+            {'pattern': '', 'objects': objects_lst})
+        self.assertEqual(res, [(1, ''), (2, '')])
+
+    def test_generate_names_2(self):
+        """Generate names using iterator object. Specified key."""
+        dummy_1 = Dummy(c=10)
+        dummy_1_2 = Dummy(b=dummy_1)
+        dummy_1_3 = Dummy(a=dummy_1_2, b='something', key=1)
+        dummy_2 = Dummy(c=50)
+        dummy_2_2 = Dummy(b=dummy_2)
+        dummy_2_3 = Dummy(a=dummy_2_2, b='something2', key=2)
+        objects_lst = [dummy_1_3, dummy_2_3]
+        res = formatting.generate_names(
+            {'pattern': '{a.b.c} | {b}', 'objects': objects_lst, 'key': 'key'})
+        self.assertEqual(res, [(1, '10 | something'), (2, '50 | something2')])
+
+    def test_generate_names_3(self):
+        """Try to call generate_names without required keys."""
+        self.assertRaises(
+            ValueError, formatting.generate_names, {'pattern': ''})
+        self.assertRaises(
+            ValueError, formatting.generate_names, {'objects': []})
 
     def test_replace_email_name_1(self):
         """Replace name for email 'A <a@b.com>'."""

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='footil',
-    version='0.7.0',
+    version='0.8.0',
     packages=['footil', 'footil.lib'],
     license='LGPLv3',
     url='https://github.com/focusate/footil',


### PR DESCRIPTION
Now possible to specify attribute name to use as key when generating
list of tuple pairs (key, name). If not specified, will default to 'id'
attribute. Also replaced arguments with single argument called `cfg`,
because there were too many arguments already.

[BRANCH] feature/generate-names-imp-ala