### PR TITLE
[ADD] parsing.py, file.py

### DIFF
--- a/footil/file.py
+++ b/footil/file.py
@@ -1,0 +1,39 @@
+import tempfile
+
+
+def WrittenNamedTemporaryFile(
+    data,
+    mode='w+b',
+    buffering=-1,
+    encoding=None,
+    newline=None,
+    suffix=None,
+    prefix=None,
+    dir=None,
+    delete=True,
+    seek=None,
+        close=False):
+    """Create NamedTeporaryFile and write data on it.
+
+    It works the same as NamedTemporaryFile except that it also writes
+    data on temp file, with possibility of changing stream position at
+    the start and/or closing temp file (when for example it is not
+    deleted and will be used later).
+
+    Write mode must be used here.
+    """
+    f = tempfile.NamedTemporaryFile(
+        mode=mode,
+        buffering=buffering,
+        encoding=encoding,
+        newline=newline,
+        dir=dir,
+        prefix=prefix,
+        suffix=suffix,
+        delete=delete)
+    f.write(data)
+    if seek is not None:
+        f.seek(seek)
+    if close:
+        f.close()
+    return f

--- a/footil/parsing.py
+++ b/footil/parsing.py
@@ -1,0 +1,88 @@
+"""Parse arbitrary data using various helpers."""
+import builtins
+
+
+def get_globals_locals(cfg: dict) -> tuple:
+    """Get globals and locals dicts that could be used for eval/exec.
+
+    Args:
+        cfg: configuration structure:
+            {
+                'all_builtins': bool,
+                'excluded_builtins': list,
+                'included_builtins': list,
+                # priority:
+                # all_builtins -> excluded_builtins -> included_builtins
+                'globals': dict,
+                'locals': dict
+            }
+
+    Returns:
+        (_globals, _locals)
+
+    """
+    def filter_builtins(filter_func):
+        for k, v in builtins.__dict__.items():
+            if filter_func(k):
+                _globals['__builtins__'][k] = v
+
+    def set_builtins(
+            all_builtins=False, excluded_builtins=(), included_builtins=()):
+        if all_builtins:
+            # Makes it include builtins, because it is required to
+            # explicitly specify to not included it.
+            del _globals['__builtins__']
+        elif excluded_builtins:
+            filter_builtins(lambda k: k not in excluded_builtins)
+        elif included_builtins:
+            filter_builtins(lambda k: k in included_builtins)
+
+    _globals = cfg.get('globals', {})
+    # builtins excluded explicitly.
+    _globals['__builtins__'] = {}
+    all_builtins = cfg.get('all_builtins', False)
+    excluded_builtins = cfg.get('excluded_builtins', [])
+    included_builtins = cfg.get('included_builtins', [])
+    set_builtins(all_builtins, excluded_builtins, included_builtins)
+    _locals = cfg.get('locals')
+    # None means, that _globals will be used on _locals.
+    if _locals is not None:
+        # Calling second .get, because locals could be False.
+        _locals = cfg.get('locals', {})
+    return (_globals, _locals)
+
+
+def eval_limited(source: str, cfg: dict = None):
+    """Evaluate source with limited globals/locals.
+
+    Can specify how to limit eval function, to not expose to more
+    context than it is needed. On default no globals and locals are
+    included.
+
+    Args:
+        source: source to evaluate.
+        cfg: configuration to set globals/locals.
+    """
+    if not cfg:
+        cfg = {}
+    _globals, _locals = get_globals_locals(cfg)
+    # evaluate source with given context if any.
+    return eval(source, _globals, _locals)
+
+
+def exec_limited(source: str, cfg: dict = None):
+    """Execute source with limited globals/locals.
+
+    Can specify how to limit exec function, to not expose to more
+    context than it is needed. On default no globals and locals are
+    included.
+
+    Args:
+        source: source to execute.
+        cfg: configuration to set globals/locals.
+    """
+    if not cfg:
+        cfg = {}
+    _globals, _locals = get_globals_locals(cfg)
+    # evaluate source with given context if any.
+    return exec(source, _globals, _locals)

--- a/footil/tests/__init__.py
+++ b/footil/tests/__init__.py
@@ -5,6 +5,9 @@ from . import (
     test_xtyping,
     test_path,
     test_date,
+    test_formatting,
+    test_parsing,
+    test_file,
 )
 __all__ = [
     'common',
@@ -12,5 +15,8 @@ __all__ = [
     'test_log',
     'test_xtyping',
     'test_path',
-    'test_date'
+    'test_date',
+    'test_formatting',
+    'test_parsing',
+    'test_file',
 ]

--- a/footil/tests/test_file.py
+++ b/footil/tests/test_file.py
@@ -1,0 +1,42 @@
+from . import common
+from footil import file
+
+
+class TestFile(common.TestFootilCommon):
+    """Test cases for module xos."""
+
+    @classmethod
+    def setUpClass(cls):
+        """Set up data for file module tests."""
+        super(TestFile, cls).setUpClass()
+        cls.data = 'test1234'
+
+    def test_written_named_temporary_file_1(self):
+        """Create temp file with data written on it.
+
+        File is kept open and without changing stream position.
+        """
+        f = file.WrittenNamedTemporaryFile(self.data, mode='w+t', delete=False)
+        self.assertFalse(f.closed)
+        self.assertEqual(f.read(), '')
+
+    def test_written_named_temporary_file_2(self):
+        """Create temp file with data written on it.
+
+        File steam position is set to start.
+        """
+        f = file.WrittenNamedTemporaryFile(
+            self.data, mode='w+t', delete=False, seek=0)
+        self.assertFalse(f.closed)
+        self.assertEqual(f.read(), self.data)
+
+    def test_written_named_temporary_file_3(self):
+        """Create temp file with data written on it.
+
+        File is closed.
+        """
+        f = file.WrittenNamedTemporaryFile(
+            self.data, mode='w+t', delete=False, close=True)
+        self.assertTrue(f.closed)
+        f = open(f.name)
+        self.assertEqual(f.read(), self.data)

--- a/footil/tests/test_parsing.py
+++ b/footil/tests/test_parsing.py
@@ -1,0 +1,108 @@
+from footil import parsing
+
+from .common import TestFootilCommon
+
+
+class TestParsing(TestFootilCommon):
+    """Test cases for parsing module."""
+
+    def test_eval_limited_1(self):
+        """Eval with no context."""
+        res = parsing.eval_limited('1')
+        self.assertEqual(res, 1)
+
+    def test_eval_limited_2(self):
+        """Eval with some builtins only."""
+        res = parsing.eval_limited(
+            'len([1, 2])', {'included_builtins': ['len']})
+        self.assertEqual(res, 2)
+        # excluded_builtins takes priority over excluded_builtins.
+        res = parsing.eval_limited(
+            'len([1, 2])',
+            {
+                'excluded_builtins': ['zip'],
+                'included_builtins': ['abs']
+            }
+        )
+        self.assertEqual(res, 2)
+        res = parsing.eval_limited(
+            'len([1, 2])', {'excluded_builtins': ['zip']}
+        )
+        self.assertEqual(res, 2)
+        with self.assertRaises(NameError):
+            parsing.eval_limited(
+                'len([1, 2])', {'included_builtins': ['abs']})
+        with self.assertRaises(NameError):
+            parsing.eval_limited(
+                'len([1, 2])',
+                {
+                    'excluded_builtins': ['len'],
+                    'included_builtins': ['abs']
+                }
+            )
+
+    def test_eval_limited_3(self):
+        """Eval with builtins, independent globals and locals."""
+        global_x = 'x1'
+        local_x = 'x2'
+        not_included_x = 'x3'  # noqa
+        res = parsing.eval_limited(
+            'len([x1, x2])',
+            {
+                'included_builtins': ['len'],
+                'globals': {'x1': global_x},
+                'locals': {'x2': local_x}
+            }
+        )
+        self.assertEqual(res, 2)
+        with self.assertRaises(NameError):
+            parsing.eval_limited(
+                'len([x1, x2, not_included_x])',
+                {
+                    'included_builtins': ['len'],
+                    'globals': {'x1': global_x},
+                    'locals': {'x2': local_x}
+                }
+            )
+        # Use all_builtins flag to have all builtins, so
+        # excluded_builtins would be ignored.
+        res = parsing.eval_limited(
+            'len([1, 2, 3])',
+            {
+                'all_builtins': True,
+                'excluded_builtins': ['len'],
+            }
+        )
+        self.assertEqual(res, 3)
+
+    def test_exec_limited_1(self):
+        """Execute source with included variable in locals."""
+        x = 10
+        _locals = {'x': x}
+        parsing.exec_limited(
+            'x += 5', {'locals': _locals, 'all_builtins': True})
+        self.assertEqual(_locals['x'], 15)
+
+    def test_exec_limited_2(self):
+        """Execute source with included variable in globals.
+
+        Case 1: locals use globals.
+        Case 2: use explicit locals, so modifications would not
+        persist.
+        """
+        x = 10
+        _globals = {'x': x}
+        parsing.exec_limited(
+            'x += 5', {'globals': _globals, 'all_builtins': True})
+        self.assertEqual(_globals['x'], 15)
+        parsing.exec_limited(
+            'x += 5',
+            {'globals': _globals, 'locals': {}, 'all_builtins': True})
+        # Value should not change, because locals is not None, meaning
+        # x from globals won't persist.
+        self.assertEqual(_globals['x'], 15)
+
+    def test_exec_limited_3(self):
+        """Execute source with not included variable."""
+        with self.assertRaises(NameError):
+            parsing.exec_limited('x += 5')

--- a/footil/tests/test_path.py
+++ b/footil/tests/test_path.py
@@ -3,13 +3,13 @@ from footil import path
 import os
 
 
-class TestXos(common.TestFootilCommon):
+class TestPath(common.TestFootilCommon):
     """Test cases for module xos."""
 
     @classmethod
     def setUpClass(cls):
-        """Set up data for xos module tests."""
-        super(TestXos, cls).setUpClass()
+        """Set up data for path module tests."""
+        super(TestPath, cls).setUpClass()
         cls.cfd = path.get_cfp(fdir=True)
 
     def test_get_cfp(self):

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='footil',
-    version='0.8.0',
+    version='0.9.0',
     packages=['footil', 'footil.lib'],
     license='LGPLv3',
     url='https://github.com/focusate/footil',


### PR DESCRIPTION
eval_limited, exec_limited helpers can be used when eval/exec need to
be called with limited context.

WrittenNamedTemporaryFile helper is a wrapper for NamedTemporaryFile
that writes data on temp file creation. It can be convenient, when some
data must be populated before file is used.

[BRANCH] feature/eval-limited-ala