### PR TITLE
[IMP] formatting.py: replace_ic

### DIFF
--- a/footil/formatting.py
+++ b/footil/formatting.py
@@ -283,3 +283,31 @@ def replace_email_name(name: str, oldemail: str) -> str:
     """Replace email name with new one."""
     _, email_part = parseaddr(oldemail)
     return formataddr((name, email_part))
+
+
+# String formatting
+
+def replace_ic(
+    term: str,
+    to_replace: str,
+        replace_with: Optional[str] = '') -> str:
+    """Replace fragment in term with other fragment (ignore case).
+
+    This is case-insensitive replacement, e.g. words 'Hello' and
+    'heLLo' will be replaced if key to replace is 'HELLO', 'HeLlo'
+    and etc.
+
+    Args:
+        term (str): term where fragment to replace will be searched
+            for and replaced with new fragment.
+        to_replace (str): fragment to be replaced (old fragment).
+        replace_with (str): fragment to be replaced with
+            (new fragment) (default: {''}).
+    Returns:
+        new term where old fragment (to_replace) in term is replaced
+        with new fragment (to_replace).
+        str
+
+    """
+    insensitive_fragment = re.compile(to_replace, re.IGNORECASE)
+    return insensitive_fragment.sub(replace_with, term)

--- a/footil/tests/test_formatting.py
+++ b/footil/tests/test_formatting.py
@@ -290,3 +290,21 @@ class TestFormatting(TestFootilCommon):
         """Replace name for email '' when name is ''."""
         email = formatting.replace_email_name('', '')
         self.assertEqual(email, '')
+
+    def test_replace_ic_1(self):
+        """Replace 'HelLo' with default replace_with ('')."""
+        new_term = formatting.replace_ic('Hello and heLLo And hello', 'HelLo')
+        self.assertEqual(new_term, ' and  And ')
+
+    def test_replace_ic_2(self):
+        """Replace 'HelLo' with 'byE' (existing fragment)."""
+        new_term = formatting.replace_ic(
+            'Hello and heLLo And hello', 'HelLo', 'byE')
+        self.assertEqual(new_term, 'byE and byE And byE')
+
+    def test_replace_ic_3(self):
+        """Replace 'byE' with 'HelLo' (non existing fragment)."""
+        new_term = formatting.replace_ic(
+            'Hello and heLLo And hello', 'byE', 'HelLo')
+        # Term should left unchanged.
+        self.assertEqual(new_term, 'Hello and heLLo And hello')

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='footil',
-    version='0.10.0',
+    version='0.11.0',
     packages=['footil', 'footil.lib'],
     license='LGPLv3',
     url='https://github.com/focusate/footil',


### PR DESCRIPTION
Adding string manipulation helper - `replace_ic`. This can be used to
replace some fragment in term with another fragment case-insensitively.

[BRANCH] feature/str_replace_ic_sbu