### PR TITLE
[ADD] path.py: get_ancestor

### DIFF
--- a/footil/path.py
+++ b/footil/path.py
@@ -1,6 +1,7 @@
 """Helper functions for paths manipulation."""
 import os
 import pathlib
+import operator
 from contextlib import contextmanager
 import inspect
 
@@ -34,8 +35,37 @@ def chdir_tmp(path: str) -> None:
         os.chdir(oldpwd)
 
 
+def get_ancestor(path: str, level=1):
+    """Return ancestor path object by specified level."""
+    path_obj = pathlib.Path(path)
+    if not level:
+        return path_obj
+    path_to_parents = '.'.join(['parent' for i in range(level)])
+    f = operator.attrgetter(path_to_parents)
+    return f(path_obj)
+
+
+def get_ancestor_name(path: str, level=1) -> str:
+    """Return ancestor path name by specified level.
+
+    >>> get_ancestor_name('a/b', level=0)
+    'b'
+    >>> get_ancestor_name('a/b.py', level=0)
+    'b.py'
+    >>> get_ancestor_name('a/b')
+    'a'
+    >>> get_ancestor_name('a/b/c.py', level=2)
+    'a'
+    >>> get_ancestor_name('a/b/c.py', level=3)
+    ''
+    """
+    return get_ancestor(path, level=level).name
+
+
 def get_parent_name(path: str) -> str:
     """Return parent path name.
+
+    Deprecated: use get_ancestor_name.
 
     >>> get_parent_name('a/b')
     'a'
@@ -50,4 +80,4 @@ def get_parent_name(path: str) -> str:
     >>> get_parent_name('')
     ''
     """
-    return pathlib.Path(path).parent.name
+    return get_ancestor_name(path, level=1)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='footil',
-    version='0.14.0',
+    version='0.15.0',
     packages=['footil', 'footil.lib'],
     license='LGPLv3',
     url='https://github.com/focusate/footil',


### PR DESCRIPTION
Lets find ancestor (n parent from path) by specifying path and level to
go up. get_ancestor_name is a helper to just return ancestor name.

get_parent_name is now deprecated.

[BRANCH] feature/path-ancestor-name-ala