### PR TITLE
[IMP] date.py: check date string satisfies format

### DIFF
--- a/footil/date.py
+++ b/footil/date.py
@@ -4,7 +4,6 @@ from dateutil.relativedelta import relativedelta
 from typing import Optional
 
 DATE_FMT = '%Y-%m-%d'
-DATETIME_FMT = '%Y-%m-%d %H:%M:%S'
 
 
 def _modify_date(

--- a/footil/datetime.py
+++ b/footil/datetime.py
@@ -1,0 +1,12 @@
+"""Helpers for datetime manipulation."""
+import datetime
+from typing import Optional
+
+DATETIME_FMT = '%Y-%m-%d %H:%M:%S'
+
+
+def to_datetime(
+    dt: str,
+        fmt: Optional[str] = DATETIME_FMT) -> datetime.datetime:
+    """Convert date/-time string to datetime.datetime object."""
+    return datetime.datetime.strptime(dt, fmt)

--- a/footil/tests/test_date.py
+++ b/footil/tests/test_date.py
@@ -1,16 +1,19 @@
 from footil.date import (
     get_first_day_date_str, get_last_day_date_str,
-    get_first_day_date, get_last_day_date, DATE_FMT
+    get_first_day_date, get_last_day_date, DATE_FMT,
+    to_date
 )
-from datetime import datetime
+import datetime
 
 from . import common
+
+DTTM = datetime.datetime
 
 
 class TestDateManipulation(common.TestFootilCommon):
     """Class to test date manipulation functions."""
 
-    def test_get_first_day_date(self):
+    def test_01_get_first_day_date(self):
         """Get first day date for provided date string."""
         res = get_first_day_date_str('1989-02-19')
         self.assertEqual(res, '1989-02-01')
@@ -27,15 +30,15 @@ class TestDateManipulation(common.TestFootilCommon):
         res = get_first_day_date_str('1989-02-19', months=-2)
         self.assertEqual(res, '1988-12-01')
         # Test with datetime.date object, date object to return
-        dt = datetime.strptime('1989-02-19', DATE_FMT).date()
-        res_dt = datetime.strptime('1988-12-01', DATE_FMT).date()
+        dt = DTTM.strptime('1989-02-19', DATE_FMT).date()
+        res_dt = DTTM.strptime('1988-12-01', DATE_FMT).date()
         self.assertEqual(get_first_day_date(dt, months=-2), res_dt)
         # Test with datetime.date object, but other date format
-        dt = datetime.strptime('1989.02.19', '%Y.%m.%d').date()
-        res_dt = datetime.strptime('1989.02.01', '%Y.%m.%d').date()
+        dt = DTTM.strptime('1989.02.19', '%Y.%m.%d').date()
+        res_dt = DTTM.strptime('1989.02.01', '%Y.%m.%d').date()
         self.assertEqual(get_first_day_date(dt), res_dt)
 
-    def test_get_last_day_date(self):
+    def test_02_get_last_day_date(self):
         """Get last day date for provided date."""
         res = get_last_day_date_str('1989-02-19')
         self.assertEqual(res, '1989-02-28')
@@ -53,10 +56,43 @@ class TestDateManipulation(common.TestFootilCommon):
         res = get_last_day_date_str('1989-02-19', months=-2)
         self.assertEqual(res, '1988-12-31')
         # Test with datetime.date object, date object to return
-        dt = datetime.strptime('1989-02-19', DATE_FMT).date()
-        res_dt = datetime.strptime('1988-12-31', DATE_FMT).date()
+        dt = DTTM.strptime('1989-02-19', DATE_FMT).date()
+        res_dt = DTTM.strptime('1988-12-31', DATE_FMT).date()
         self.assertEqual(get_last_day_date(dt, months=-2), res_dt)
         # Test with datetime.date object, but other date format
-        dt = datetime.strptime('1989.02.19', '%Y.%m.%d').date()
-        res_dt = datetime.strptime('1989.02.28', '%Y.%m.%d').date()
+        dt = DTTM.strptime('1989.02.19', '%Y.%m.%d').date()
+        res_dt = DTTM.strptime('1989.02.28', '%Y.%m.%d').date()
         self.assertEqual(get_last_day_date(dt), res_dt)
+
+    def test_03_to_date(self):
+        """Check when date string satisfies date format."""
+        # default format
+        try:
+            to_date('2020-01-01')
+        except ValueError:
+            self.fail("Should not fail. '2020-01-01' fits default format.")
+        # custom formats
+        try:
+            to_date('2020', '%Y')
+        except ValueError:
+            self.fail("Should not fail. '2020' fits given format.")
+        try:
+            to_date('2020/12', '%Y/%m')
+        except ValueError:
+            self.fail("Should not fail. '2020/12' fits given format.")
+        # datetime
+        try:
+            dt = to_date('2020/12 15:20', '%Y/%m %M:%S')
+        except ValueError:
+            self.fail("Should not fail. '2020/12 15:20' fits given format.")
+        self.assertEqual(type(dt), datetime.date)
+
+    def test_04_to_date(self):
+        """Check when date string does not satisfy date format."""
+        # default format
+        self.assertRaises(ValueError, to_date, '2020/01/01')
+        # custom formats
+        self.assertRaises(ValueError, to_date, '2020/01/01', '%Y')
+        self.assertRaises(ValueError, to_date, '2020', '%Y/%m')
+        # datetime
+        self.assertRaises(ValueError, to_date, '2020 15:20', '%Y %m')

--- a/footil/tests/test_datetime.py
+++ b/footil/tests/test_datetime.py
@@ -1,0 +1,32 @@
+from footil.datetime import to_datetime
+
+import datetime
+
+from . import common
+
+
+class TestDatetimeManipulation(common.TestFootilCommon):
+    """Class to test datetime manipulation functions."""
+
+    def test_01_to_datetime(self):
+        """Check with default format."""
+        # valid
+        try:
+            dt = to_datetime('2020-01-01 01:05:20')
+        except ValueError:
+            self.fail(
+                "Should not fail. '2020-01-01 01:05:20' fits default format.")
+        self.assertEqual(type(dt), datetime.datetime)
+        # invalid
+        self.assertRaises(ValueError, to_datetime, '2020/01/01 01:05:20')
+
+    def test_02_to_datetime(self):
+        """Check with custom format."""
+        # valid
+        try:
+            dt = to_datetime('2020-01 01:20', '%Y-%d %M:%H')
+        except ValueError:
+            self.fail("Should not fail. '2020-01 01:20' fits custom format.")
+        self.assertEqual(type(dt), datetime.datetime)
+        # invalid
+        self.assertRaises(ValueError, to_datetime, '2020 01:20', '%Y-%d %M:%H')

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from distutils.core import setup
 
 setup(
     name='footil',
-    version='0.19.0',
+    version='0.20.0',
     packages=['footil', 'footil.lib'],
     license='LGPLv3',
     url='https://github.com/focusate/footil',


### PR DESCRIPTION
Methods `check_date_str`, `check_datetime_str` checks if date/-time
strings satisfies certain format. Those methods are identical, except
default formats are different for convenience.

[BRANCH] feature/check-date-str-sbu